### PR TITLE
Change lib to handle lockless collections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ keywords = [ "parallel", "performance", "thread", "join", "concurrency"]
 categories = [ "concurrency" ]
 
 [dependencies]
-rayon = "1.3.0"
+rayon = "1.3"
 crossbeam-queue = { version = "0.2", optional = true }

--- a/README.md
+++ b/README.md
@@ -7,17 +7,21 @@ A `DynQueue<T>` can be iterated with `into_par_iter` producing `(DynQueueHandle,
 With the `DynQueueHandle<T>` a new `T` can be inserted in the `DynQueue<T>`,
 which is currently iterated over.
 
-```rust
-use dynqueue::DynQueue;
+A `Vec<T>`, `VecDeque<T>` and `crossbeam_queue::SegQueue<T>` (with `feature = "crossbeam-queue"`)
+can be turned into a `DynQueue<T>` with `.into_dyn_queue()`.
 
+```rust
 use rayon::iter::IntoParallelIterator as _;
 use rayon::iter::ParallelIterator as _;
 
+use dynqueue::IntoDynQueue as _;
+
 fn main() {
-    let mut result = DynQueue::new(vec![1, 2, 3])
-                         .into_par_iter()
-                         .map(|(handle, value)| { if value == 2 { handle.enqueue(4) }; value })
-                         .collect::<Vec<_>>();
+    let mut result = vec![1, 2, 3]
+        .into_dyn_queue()
+        .into_par_iter()
+        .map(|(handle, value)| { if value == 2 { handle.enqueue(4) }; value })
+        .collect::<Vec<_>>();
     result.sort();
 
     assert_eq!(result, vec![1, 2, 3, 4]);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::{DynQueue, DynQueueHandle, Queue};
+use crate::{DynQueueHandle, IntoDynQueue, Queue};
 use std::collections::VecDeque;
 
 const SLEEP_MS: u64 = 10;
@@ -49,7 +49,7 @@ fn dynqueue_iter_test_const_sleep() {
 
     let med = expected.iter().sum::<u64>() / expected.iter().count() as u64;
 
-    let jq = DynQueue::new(get_input());
+    let jq = get_input().into_dyn_queue();
     let now = std::time::Instant::now();
 
     let mut res = jq
@@ -79,13 +79,13 @@ fn dynqueue_iter_test_const_sleep_segqueue() {
     let expected = get_expected();
 
     let med = expected.iter().sum::<u64>() / expected.iter().count() as u64;
-    let q = SegQueue::new();
-    get_input().drain(..).for_each(|ele| q.push(ele));
+    let jq = SegQueue::new();
+    get_input().drain(..).for_each(|ele| jq.push(ele));
 
-    let jq = DynQueue::new(q);
     let now = std::time::Instant::now();
 
     let mut res = jq
+        .into_dyn_queue()
         .into_par_iter()
         .map(handle_queue)
         .map(|v| {
@@ -111,10 +111,11 @@ fn dynqueue_iter_test_const_sleep_vecdeque() {
 
     let med = expected.iter().sum::<u64>() / expected.iter().count() as u64;
 
-    let jq = DynQueue::new(VecDeque::from(get_input()));
+    let jq = VecDeque::from(get_input());
     let now = std::time::Instant::now();
 
     let mut res = jq
+        .into_dyn_queue()
         .into_par_iter()
         .map(handle_queue)
         .map(|v| {
@@ -137,11 +138,12 @@ fn dynqueue_iter_test_sleep_v() {
     use rayon::iter::ParallelIterator as _;
     use std::time::Duration;
 
-    let jq = DynQueue::new(get_input());
+    let jq = get_input();
 
     let now = std::time::Instant::now();
 
     let mut res = jq
+        .into_dyn_queue()
         .into_par_iter()
         .map(handle_queue)
         .map(|v| {
@@ -161,11 +163,12 @@ fn dynqueue_iter_test_sleep_inv_v() {
     use rayon::iter::ParallelIterator as _;
     use std::time::Duration;
 
-    let jq = DynQueue::new(get_input());
+    let jq = get_input();
 
     let now = std::time::Instant::now();
 
     let mut res = jq
+        .into_dyn_queue()
         .into_par_iter()
         .map(handle_queue)
         .map(|v| {


### PR DESCRIPTION
crossbeam_queue::SegQueue does not need a guarding RwLock.

Fixes: https://github.com/haraldh/dynqueue/issues/4