### PR TITLE
Update coverage workflow to use llvm-cov and Codecov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,29 +1,34 @@
-name:                           coverage
+name: Coverage
 
 on:
+  # Trigger the workflow on push or pull request,
+  # but only for the master branch
   push:
     branches:
       - master
   pull_request:
     branches:
       - master
+  release:
+    types:
+      - created
 
 jobs:
-  test:
-    name:                       coverage
-    runs-on:                    ubuntu-latest
-    container:
-      image:                    xd009642/tarpaulin
-      options:                  --security-opt seccomp=unconfined
+  coverage:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
     steps:
-      - name:                   Checkout repository
-        uses:                   actions/checkout@v2
-
-      - name:                   Generate code coverage
-        run: |
-          cargo tarpaulin --verbose --all-features --workspace --timeout 120 --out Lcov --output-dir coverage
-
-      - name:                   Upload to coveralls
-        uses: coverallsapp/github-action@master
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        run: rustup update stable
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Generate code coverage
+        run: cargo llvm-cov --all-features --workspace --codecov --output-path codecov.json
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
+          files: codecov.json
+          fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -1,31 +1,39 @@
 [![Rust](https://github.com/haraldh/dynqueue/workflows/Rust/badge.svg)](https://github.com/haraldh/dynqueue/actions)
-[![Coverage Status](https://coveralls.io/repos/github/haraldh/dynqueue/badge.svg?branch=master)](https://coveralls.io/github/haraldh/dynqueue?branch=master)
+[![Coverage Status](https://codecov.io/gh/haraldh/dynqueue/graph/badge.svg?token=E2KO8O9W9O)](https://codecov.io/gh/haraldh/dynqueue)
 
 # DynQueue - dynamically extendable Rayon parallel iterator
 
-DynQueue is a Rust library that provides a specialized parallel iterator built on top of the Rayon parallel computing framework. Its key feature is the ability to dynamically add new items to the collection while it's being processed in parallel.
+DynQueue is a Rust library that provides a specialized parallel iterator built on top of the Rayon parallel computing
+framework. Its key feature is the ability to dynamically add new items to the collection while it's being processed in
+parallel.
 
-This project fills a specific niche in the Rust parallel computing ecosystem by providing a way to work with dynamically growing workloads in a parallel context, something that's not directly supported by Rayon itself.
+This project fills a specific niche in the Rust parallel computing ecosystem by providing a way to work with dynamically
+growing workloads in a parallel context, something that's not directly supported by Rayon itself.
 
 ## Core Functionality:
+
 - Allows adding new elements to a collection while it's being iterated over in parallel
 - Works with multiple collection types: `Vec`, `VecDeque`, and `crossbeam_queue::SegQueue` (via feature flag)
 - Uses Rayon's parallel iteration capabilities for efficient parallel processing
 - Provides a clean API for dynamically expanding workloads
 
 ## Technical Implementation:
+
 - Implements Rayon's parallel iteration traits
 - Uses a handle-based approach where each iterator function receives a handle to insert new items
 - Thread-safe implementation using RwLock and Arc for standard collections
 - Optional integration with crossbeam's lock-free SegQueue
 
 ## Use Cases:
+
 The library is particularly useful for:
+
 - Tree/graph traversal algorithms where new nodes are discovered during processing
 - Work-stealing parallel algorithms where work can be dynamically generated
 - Any parallel processing task where the total workload is not known upfront
 
 ## Example Usage:
+
 ```rust
 use rayon::iter::IntoParallelIterator as _;
 use rayon::iter::ParallelIterator as _;
@@ -35,11 +43,11 @@ fn main() {
     let mut result = vec![1, 2, 3]
         .into_dyn_queue()
         .into_par_iter()
-        .map(|(handle, value)| { 
-            if value == 2 { 
-                handle.enqueue(4) 
-            }; 
-            value 
+        .map(|(handle, value)| {
+            if value == 2 {
+                handle.enqueue(4)
+            };
+            value
         })
         .collect::<Vec<_>>();
     result.sort();
@@ -57,7 +65,6 @@ which is currently iterated over.
 A `Vec<T>`, `VecDeque<T>` and `crossbeam_queue::SegQueue<T>` (with `feature = "crossbeam-queue"`)
 can be turned into a `DynQueue<T>` with `.into_dyn_queue()`.
 
-
 ## Features
 
 * `crossbeam-queue` : to use `crossbeam::queue::SegQueue` as the inner collection.
@@ -65,8 +72,10 @@ can be turned into a `DynQueue<T>` with `.into_dyn_queue()`.
 ## Changelog
 
 ### 0.2.0
+
 - introduce `IntoDynQueue`
 - handle lockless collections
 
 ### 0.1.0
+
 - initial version


### PR DESCRIPTION
Switched from tarpaulin and Coveralls to llvm-cov and Codecov for generating and uploading code coverage data. This transition modernizes the workflow, simplifies configuration, and enhances compatibility with Rust projects. Additionally, streamlined workflow triggers and naming conventions for clarity.